### PR TITLE
ci(docs): publish through the shared GitHub Pages workflow

### DIFF
--- a/.github/workflows/publish_gh_pages.yml
+++ b/.github/workflows/publish_gh_pages.yml
@@ -1,47 +1,20 @@
 name: Publish to GitHub Pages
+
 on:
-  workflow_dispatch:  
+  workflow_dispatch:
   release:
     types: [created]
   push:
     branches:
       - main
 
-concurrency:
-  group: github-pages
-  cancel-in-progress: false
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-      - name: Install Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-      - name: Install dependencies
-        run: npm ci
-      - name: Generate Site
-        run: npx antora docs/antora-playbook.yml
-      - name: Create site folders
-        run: mkdir -p docs/build/site
-      - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs/build/site
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+  publish:
+    uses: reqstool/.github/.github/workflows/common-publish-to-github-pages.yml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write


### PR DESCRIPTION
## What & Why

`publish_gh_pages.yml` was a line-for-line copy of `common-publish-to-github-pages.yml` — same checkout, Pages config, Node setup, Antora build, artifact upload, deploy. Any fix to one had to be remembered in the other. It now calls the shared workflow.

Two differences, both in the shared one’s favour:

- It passes `--log-failure-level=fatal` to Antora, so a fatal is a **failed build** rather than a quietly broken site.
- The `mkdir -p docs/build/site` guard is gone. It made an Antora run that produced nothing deploy an **empty directory** instead of failing.

The repo’s own `package-lock.json` still pins Antora 3.1.15: the shared build action runs `npm ci` when it finds a lockfile, and falls back to a pinned install only when there is none.

## Author checklist

- [x] `actionlint` clean
- [x] Conventional Commit title, DCO sign-off
- [x] Triggers unchanged (`workflow_dispatch`, `release: created`, push to `main`)

## Test Plan

**Merge after [reqstool/.github#66](https://github.com/reqstool/.github/pull/66)** — the shared workflow gains the `build-antora-site` action there.

Then push to `main` (or dispatch) and confirm the site builds and deploys as before.